### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Potential fix for [https://github.com/envm-org/envm/security/code-scanning/2](https://github.com/envm-org/envm/security/code-scanning/2)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the minimal set required. For this workflow, the job only needs to read repository contents to run `govulncheck`, so we can set `contents: read`. No write permissions appear necessary.

The best fix with no functional change is to add a `permissions` section to the `govulncheck` job, right under `runs-on: ubuntu-latest`. This will apply only to this job and override any broader repository defaults. We set `permissions: contents: read`, which is sufficient for `actions/checkout` and for reading code during the analysis. No additional imports, methods, or external libraries are required, since this is purely a YAML configuration change in `.github/workflows/govulncheck.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
